### PR TITLE
Fix profile retrieval for colloquial current-role queries

### DIFF
--- a/backend/app/services/retrieval.py
+++ b/backend/app/services/retrieval.py
@@ -70,7 +70,10 @@ _SYNONYMS: dict[str, str] = {
 }
 
 _PROFILE_KEY_SYNONYMS: dict[str, frozenset[str]] = {
-    "current_role": frozenset({"current", "role", "job", "title", "work", "works", "working", "company"}),
+    "current_role": frozenset({
+        "current", "role", "job", "title", "work", "works", "working", "company",
+        "up", "doing", "now", "currently", "nowadays", "lately",
+    }),
     "education": frozenset({"education", "degree", "studied", "study", "major", "college", "colby", "university", "graduate", "graduated"}),
     "interests": frozenset({"interest", "interests", "hobby", "hobbies", "outside", "personal", "free", "spare"}),
 }
@@ -93,6 +96,9 @@ _GENERAL_WORK_QUERY_PATTERNS = (
     re.compile(r"\bwhat projects?(?: has)? (?:she|yixin)(?:\s+li)?(?: worked on| done)?\b"),
     re.compile(r"\bwhat projects?\b"),
     re.compile(r"\bwhat kind of work\b"),
+    re.compile(r"\bwhat(?:'s| is| has she been)\s+(?:she|yixin)\s+up to\b"),
+    re.compile(r"\bwhat(?:'s| is)\s+(?:she|yixin)\s+(?:doing|working on)(?: now| these days| currently| lately)?\b"),
+    re.compile(r"\bwhere\s+(?:does|is)\s+(?:she|yixin)\s+work(?:ing)?\b"),
 )
 
 


### PR DESCRIPTION
"what's she up to?" and similar idioms scored 0.0 because tokens like "up" and "doing" had no overlap with the current_role synonym set or general-work patterns — triggering the memory fallback.

- Add "up", "doing", "now", "currently", "nowadays", "lately" to _PROFILE_KEY_SYNONYMS["current_role"]
- Add regex patterns for "what's she up to", "where does she work", "what's she doing these days" to _GENERAL_WORK_QUERY_PATTERNS