### PR TITLE
Enable local Playwright testing — fix CORS null-origin error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 .DS_Store
+node_modules/
+test-results/
+playwright-report/
 
 # Python caches
 __pycache__/

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -974,7 +974,9 @@
   (function () {
     'use strict';
     /* ── Config ── */
-    var BASE = 'https://backend-green-zeta-37.vercel.app';
+    var BASE = (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1')
+        ? 'http://localhost:8000'
+        : 'https://backend-green-zeta-37.vercel.app';
 
     var SESSION_ID = (function () {
       var id = sessionStorage.getItem('px_sid');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,76 @@
+{
+  "name": "aglyx-portfolio",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "aglyx-portfolio",
+      "devDependencies": {
+        "@playwright/test": "^1.60.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "aglyx-portfolio",
+  "private": true,
+  "scripts": {
+    "dev": "bash scripts/dev.sh",
+    "test": "npx playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.60.0"
+  }
+}

--- a/playwright.config.mjs
+++ b/playwright.config.mjs
@@ -1,0 +1,33 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  timeout: 90_000,
+  retries: 0,
+  use: {
+    baseURL: 'http://localhost:3000',
+    headless: true,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: [
+    {
+      // Backend
+      command: 'cd backend && .venv/bin/uvicorn app.main:app --port 8000',
+      url: 'http://localhost:8000/docs',
+      reuseExistingServer: true,
+      timeout: 30_000,
+    },
+    {
+      // Frontend static server
+      command: 'python3 -m http.server 3000 --directory frontend',
+      url: 'http://localhost:3000',
+      reuseExistingServer: true,
+      timeout: 10_000,
+    },
+  ],
+});

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Start local backend (port 8000) and frontend server (port 3000) for development/testing.
+set -e
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+echo "Starting backend on http://localhost:8000 ..."
+cd "$ROOT/backend"
+.venv/bin/uvicorn app.main:app --port 8000 --reload &
+BACKEND_PID=$!
+
+echo "Starting frontend on http://localhost:3000 ..."
+python3 -m http.server 3000 --directory "$ROOT/frontend" &
+FRONTEND_PID=$!
+
+trap "echo 'Stopping...'; kill $BACKEND_PID $FRONTEND_PID 2>/dev/null" EXIT INT TERM
+
+echo ""
+echo "  Frontend: http://localhost:3000"
+echo "  Backend:  http://localhost:8000/docs"
+echo ""
+echo "Press Ctrl-C to stop both servers."
+wait

--- a/tests/chat.spec.mjs
+++ b/tests/chat.spec.mjs
@@ -1,0 +1,57 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('portfolio chat', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    // Wait for bubble graph to load (confirms /graph succeeded)
+    await page.waitForSelector('.bubble-node', { timeout: 15_000 });
+  });
+
+  test('landing page loads and bubbles render', async ({ page }) => {
+    await expect(page.locator('.landing-name')).toBeVisible();
+    await expect(page.locator('.bubble-node').first()).toBeVisible();
+  });
+
+  test('chat responds without load-fail errors', async ({ page }) => {
+    const input = page.locator('.landing-input');
+    await input.fill('what does yixin work on?');
+    await input.press('Enter');
+
+    // Body should get state-chat class when chat transitions in
+    await expect(page.locator('body')).toHaveClass(/state-chat/, { timeout: 5_000 });
+
+    // Wait for actual response text (typing dots gone means response is complete)
+    await page.waitForFunction(
+      () => !document.getElementById('chatSend').disabled,
+      { timeout: 30_000 }
+    );
+    const assistantMsg = page.locator('.message-assistant').first();
+
+    const text = await assistantMsg.innerText();
+    expect(text).not.toContain('load fail');
+    expect(text).not.toContain('Load fail');
+    expect(text.length).toBeGreaterThan(20);
+  });
+
+  test('follow-up question works in same session', async ({ page }) => {
+    const input = page.locator('.landing-input');
+    await input.fill('tell me about her AI work');
+    await input.press('Enter');
+
+    await expect(page.locator('body')).toHaveClass(/state-chat/, { timeout: 5_000 });
+
+    // Wait for the response to fully arrive (typing dots gone, send button re-enabled)
+    await page.waitForFunction(
+      () => !document.getElementById('chatSend').disabled,
+      { timeout: 25_000 }
+    );
+
+    // Ask a follow-up via the composer
+    const composer = page.locator('.composer-input');
+    await composer.fill("what's her current role?");
+    await composer.press('Enter');
+
+    // Second assistant response should appear
+    await expect(page.locator('.message-assistant')).toHaveCount(2, { timeout: 40_000 });
+  });
+});


### PR DESCRIPTION
The frontend hardcoded the production backend URL, which meant file:// requests sent Origin: null and were blocked by CORS. Fix by auto-detecting localhost and pointing to a local backend instead.

- frontend/index.html: BASE URL now switches to http://localhost:8000 when served from localhost, otherwise stays on the production Vercel backend
- scripts/dev.sh: convenience script that starts both the local FastAPI backend (port 8000, using backend/.venv) and a Python HTTP server for the frontend (port 3000) with a single Ctrl-C to stop both
- package.json + playwright.config.mjs: Playwright project wired to http://localhost:3000, with webServer entries that start/reuse both servers automatically before running tests
- tests/chat.spec.mjs: three end-to-end tests — bubbles render, chat responds without load-fail errors, follow-up question works in session
- .gitignore: add node_modules/, test-results/, playwright-report/